### PR TITLE
Allowed adding of partial (i.e. one field is blank) entries to the Character Assignment

### DIFF
--- a/WhosTalking/Plugin.cs
+++ b/WhosTalking/Plugin.cs
@@ -76,9 +76,9 @@ public sealed class Plugin: IDalamudPlugin {
         // this.MainWindow.IsOpen = true;
         // this.ConfigWindow.IsOpen = true;
 #endif
-        // if (pluginInterface.Reason == PluginLoadReason.Installer) {
-        //    this.ConfigWindow.IsOpen = true;
-        // }
+        if (pluginInterface.Reason == PluginLoadReason.Installer) {
+            this.ConfigWindow.IsOpen = true;
+        }
     }
 
     public Configuration Configuration { get; init; }

--- a/WhosTalking/Plugin.cs
+++ b/WhosTalking/Plugin.cs
@@ -76,9 +76,9 @@ public sealed class Plugin: IDalamudPlugin {
         // this.MainWindow.IsOpen = true;
         // this.ConfigWindow.IsOpen = true;
 #endif
-        if (pluginInterface.Reason == PluginLoadReason.Installer) {
-            this.ConfigWindow.IsOpen = true;
-        }
+        // if (pluginInterface.Reason == PluginLoadReason.Installer) {
+        //    this.ConfigWindow.IsOpen = true;
+        // }
     }
 
     public Configuration Configuration { get; init; }

--- a/WhosTalking/Windows/ConfigWindow.cs
+++ b/WhosTalking/Windows/ConfigWindow.cs
@@ -299,14 +299,26 @@ public sealed class ConfigWindow: Window, IDisposable {
                 );
 
                 // Add entry to list
-                var _charaName = (this.playerInPartyIdx < playersInParty.Count) ? playersInParty[this.playerInPartyIdx] : "";
-                var _discId = (this.playerInPartyIdx < idsInCall.Count) ? idsInCall[this.idInCallIdx] : "";
                 ImGui.TableNextColumn();
                 if (ImGui.Button("Add Entry")) {
+                    var _charaName = (this.playerInPartyIdx < playersInParty.Count) ? playersInParty[this.playerInPartyIdx] : "";
+                    var _discId = (this.playerInPartyIdx < idsInCall.Count) ? idsInCall[this.idInCallIdx] : "";
+
                     var i = this.individualAssignments.Count;
                     this.individualAssignments.Add(new AssignmentEntry());
+
                     this.individualAssignments[i].CharacterName = _charaName;
                     this.individualAssignments[i].DiscordId = _discId;
+                }
+
+                // Blank entry button
+                ImGui.SameLine();
+                if (ImGui.Button("Add blank Entry")) {
+                    var i = this.individualAssignments.Count;
+                    this.individualAssignments.Add(new AssignmentEntry());
+
+                    this.individualAssignments[i].CharacterName = "";
+                    this.individualAssignments[i].DiscordId = "";
                 }
 
                 ImGui.EndTable();

--- a/WhosTalking/Windows/ConfigWindow.cs
+++ b/WhosTalking/Windows/ConfigWindow.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Numerics;
@@ -17,11 +18,10 @@ namespace WhosTalking.Windows;
 public sealed class ConfigWindow: Window, IDisposable {
     private readonly List<AssignmentEntry> individualAssignments;
     private readonly Plugin plugin;
-
     private readonly IDalamudTextureWrap previewImage;
-    private int idInCall;
 
-    private int playerInParty;
+    private int playerInPartyIdx;
+    private int idInCallIdx;
 
     public ConfigWindow(Plugin plugin): base(
         "Who's Talking configuration",
@@ -268,7 +268,7 @@ public sealed class ConfigWindow: Window, IDisposable {
                     ImGui.SetNextItemWidth(150);
                     ImGui.Combo(
                         "###PlayersInParty",
-                        ref this.playerInParty,
+                        ref this.playerInPartyIdx,
                         _playersInParty,
                         _playersInParty.Length
                     );
@@ -293,18 +293,20 @@ public sealed class ConfigWindow: Window, IDisposable {
                 ImGui.SetNextItemWidth(200);
                 ImGui.Combo(
                     "###IdsInCall",
-                    ref this.idInCall,
+                    ref this.idInCallIdx,
                     _idsWithName,
                     _idsWithName.Length
                 );
 
-                // Button to add entry to list
+                // Add entry to list
+                var _charaName = (this.playerInPartyIdx < playersInParty.Count) ? playersInParty[this.playerInPartyIdx] : "";
+                var _discId = (this.playerInPartyIdx < idsInCall.Count) ? idsInCall[this.idInCallIdx] : "";
                 ImGui.TableNextColumn();
                 if (ImGui.Button("Add Entry")) {
                     var i = this.individualAssignments.Count;
                     this.individualAssignments.Add(new AssignmentEntry());
-                    this.individualAssignments[i].CharacterName = playersInParty[this.playerInParty];
-                    this.individualAssignments[i].DiscordId = idsInCall[this.idInCall];
+                    this.individualAssignments[i].CharacterName = _charaName;
+                    this.individualAssignments[i].DiscordId = _discId;
                 }
 
                 ImGui.EndTable();

--- a/WhosTalking/Windows/ConfigWindow.cs
+++ b/WhosTalking/Windows/ConfigWindow.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.Design;
 using System.IO;
 using System.Linq;
 using System.Numerics;


### PR DESCRIPTION
Previously, a blank entry would be added and an error thrown.
Instead:
- The "Add Entry" button will now leave any missing field blank
- An "Add blank Entry" button has been added alongside to preserve functionality