### PR TITLE
Add option for non-rounded voice indicators in imgui rendering mode

### DIFF
--- a/WhosTalking/Configuration.cs
+++ b/WhosTalking/Configuration.cs
@@ -30,6 +30,7 @@ public sealed class Configuration: IPluginConfiguration {
     public bool ShowIndicators { get; set; } = true;
     public bool ShowUnmatchedUsers { get; set; } = true;
     public IndicatorStyle IndicatorStyle { get; set; } = IndicatorStyle.Atk;
+    public bool UseRoundedCorners { get; set; } = true;
 
     // colours are ABGR
     public uint ColourUnmatched { get; set; } = 0xFF00FFFF; // yellow

--- a/WhosTalking/Plugin.cs
+++ b/WhosTalking/Plugin.cs
@@ -277,12 +277,15 @@ public sealed class Plugin: IDalamudPlugin {
             var indicatorSize = new Vector2(gridNode->Width, gridNode->Height) * scale;
             var indicatorMin = indicatorStart + ImGui.GetMainViewport().Pos;
             var indicatorMax = indicatorStart + indicatorSize + ImGui.GetMainViewport().Pos;
+            var cornerStyle = (this.Configuration.UseRoundedCorners == true) ?
+                ImDrawFlags.RoundCornersAll :
+                ImDrawFlags.RoundCornersNone;
             drawList.AddRect(
                 indicatorMin,
                 indicatorMax,
                 this.GetColour(user),
                 7 * scale,
-                ImDrawFlags.RoundCornersAll,
+                cornerStyle,
                 (3 * scale) - 1
             );
         } else if (this.Configuration.IndicatorStyle == IndicatorStyle.Atk) {

--- a/WhosTalking/Plugin.cs
+++ b/WhosTalking/Plugin.cs
@@ -238,12 +238,15 @@ public sealed class Plugin: IDalamudPlugin {
             var indicatorSize = new Vector2(colNode->Width, colNode->Height) * scale;
             var indicatorMin = indicatorStart + ImGui.GetMainViewport().Pos;
             var indicatorMax = indicatorStart + indicatorSize + ImGui.GetMainViewport().Pos;
+            var cornerStyle = (this.Configuration.UseRoundedCorners == true) ?
+                ImDrawFlags.RoundCornersAll :
+                ImDrawFlags.RoundCornersNone;
             drawList.AddRect(
                 indicatorMin,
                 indicatorMax,
                 this.GetColour(user),
                 7 * scale,
-                ImDrawFlags.RoundCornersAll,
+                cornerStyle,
                 (3 * scale) - 1
             );
         } else if (this.Configuration.IndicatorStyle == IndicatorStyle.Atk) {

--- a/WhosTalking/Windows/ConfigWindow.cs
+++ b/WhosTalking/Windows/ConfigWindow.cs
@@ -86,6 +86,13 @@ public sealed class ConfigWindow: Window, IDisposable {
             this.plugin.Configuration.Save();
         }
 
+        var useRoundedCorners = this.plugin.Configuration.UseRoundedCorners;
+        if (this.plugin.Configuration.IndicatorStyle == IndicatorStyle.Imgui &&
+            ImGui.Checkbox("Use rounded corners for voice activity indicators (Material UI/Frost UI users, disable this!)", ref useRoundedCorners)) {
+            this.plugin.Configuration.UseRoundedCorners = useRoundedCorners;
+            this.plugin.Configuration.Save();
+        }
+
         var nonXivUsersDisplayMode = (int)this.plugin.Configuration.NonXivUsersDisplayMode;
         var nonXivUsersDisplayModes = Enum.GetValues(typeof(NonXivUsersDisplayMode))
             .Cast<NonXivUsersDisplayMode>()


### PR DESCRIPTION
I kept seeing the rounded corners so prominently with square party list job icons (via Frost UI or Material UI) so I thought I might try to add this for visual consistency

![image](https://github.com/user-attachments/assets/32b7380e-2b4f-414a-a643-981278371d8b)

![image](https://github.com/user-attachments/assets/81f73b8e-4502-4555-8fd8-b640375ff5ab)

![image](https://github.com/user-attachments/assets/c797ccd1-6ff6-4bd0-bba4-9dc1063fda1a)
