### PR TITLE
Add port configuration

### DIFF
--- a/WhosTalking/Configuration.cs
+++ b/WhosTalking/Configuration.cs
@@ -32,6 +32,7 @@ public sealed class Configuration: IPluginConfiguration {
     public bool ShowUnmatchedUsers { get; set; } = true;
     public IndicatorStyle IndicatorStyle { get; set; } = IndicatorStyle.Imgui;
     public bool UseRoundedCorners { get; set; } = true;
+    public int Port { get; set; } = 6463;
 
     // colours are ABGR
     public uint ColourUnmatched { get; set; } = 0xFF00FFFF; // yellow

--- a/WhosTalking/Discord/DiscordConnection.cs
+++ b/WhosTalking/Discord/DiscordConnection.cs
@@ -15,7 +15,7 @@ public class DiscordConnection {
     internal readonly Dictionary<string, User> AllUsers;
     private readonly Stack<Action> disposeActions = new();
     private readonly Plugin plugin;
-    private readonly WebsocketClient webSocket;
+    public readonly WebsocketClient webSocket;
     private DiscordChannel? currentChannel;
     private bool isArRpc;
     private string? userId;
@@ -23,8 +23,10 @@ public class DiscordConnection {
     public DiscordConnection(Plugin plugin) {
         this.plugin = plugin;
         this.AllUsers = new Dictionary<string, User>();
+        
+        var discordPort = this.plugin.Configuration.Port;
         this.webSocket = new WebsocketClient(
-            new Uri($"ws://127.0.0.1:6463/?v=1&client_id={ClientId}"),
+            new Uri($"ws://127.0.0.1:{discordPort}/?v=1&client_id={ClientId}"),
             () => {
                 var client = new ClientWebSocket();
                 client.Options.SetRequestHeader("Origin", "https://streamkit.discord.com");
@@ -95,6 +97,8 @@ public class DiscordConnection {
             this.plugin.Configuration.Save();
         }
     }
+    
+    private int? Port => this.plugin.Configuration.Port;
 
     public void Send(string msg) {
         this.webSocket.Send(msg);

--- a/WhosTalking/Discord/DiscordConnection.cs
+++ b/WhosTalking/Discord/DiscordConnection.cs
@@ -15,7 +15,7 @@ public class DiscordConnection {
     internal readonly Dictionary<string, User> AllUsers;
     private readonly Stack<Action> disposeActions = new();
     private readonly Plugin plugin;
-    public readonly WebsocketClient webSocket;
+    private readonly WebsocketClient webSocket;
     private DiscordChannel? currentChannel;
     private bool isArRpc;
     private string? userId;

--- a/WhosTalking/Discord/DiscordConnection.cs
+++ b/WhosTalking/Discord/DiscordConnection.cs
@@ -23,10 +23,8 @@ public class DiscordConnection {
     public DiscordConnection(Plugin plugin) {
         this.plugin = plugin;
         this.AllUsers = new Dictionary<string, User>();
-        
-        var discordPort = this.plugin.Configuration.Port;
         this.webSocket = new WebsocketClient(
-            new Uri($"ws://127.0.0.1:{discordPort}/?v=1&client_id={ClientId}"),
+            new Uri($"ws://127.0.0.1:{this.Port}/?v=1&client_id={ClientId}"),
             () => {
                 var client = new ClientWebSocket();
                 client.Options.SetRequestHeader("Origin", "https://streamkit.discord.com");
@@ -98,7 +96,7 @@ public class DiscordConnection {
         }
     }
     
-    private int? Port => this.plugin.Configuration.Port;
+    private int Port => this.plugin.Configuration.Port;
 
     public void Send(string msg) {
         this.webSocket.Send(msg);

--- a/WhosTalking/Plugin.cs
+++ b/WhosTalking/Plugin.cs
@@ -142,6 +142,12 @@ public sealed class Plugin: IDalamudPlugin {
         this.ConfigWindow.IsOpen = true;
     }
 
+    public void ReconnectDiscord() {
+        this.Connection.Dispose();
+        this.Connection = new DiscordConnection(this);
+        this.disposeActions.Push(() => this.Connection.Dispose());
+    }
+
     private uint GetColour(User? user) {
         if (user == null) {
             return this.Configuration.ShowUnmatchedUsers ? this.Configuration.ColourUnmatched : 0;

--- a/WhosTalking/Windows/ConfigWindow.cs
+++ b/WhosTalking/Windows/ConfigWindow.cs
@@ -161,6 +161,28 @@ public sealed class ConfigWindow: Window, IDisposable {
             this.plugin.Configuration.Save();
         }
 
+        var discordPort = this.plugin.Configuration.Port;
+        if (ImGui.InputInt("Discord port", ref discordPort)) {
+            this.plugin.Configuration.Port = discordPort;
+            this.plugin.Configuration.Save();
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Is your Discord running on a different port? Default: 6463.\n"
+                + "Useful when running multiple clients or other software blocking the default port.\n"
+                + "If a port is already in use increment the port by one and try again.\n"
+                + "If in doubt, leave it/set to default 6463!");
+        }
+        if (ImGui.Button("Reconnect")) {
+            this.plugin.ReconnectDiscord();
+        }
+        if (ImGui.IsItemHovered()) {
+            ImGui.SetTooltip("Try to connect to the set port.");
+        }
+        
+        ImGui.SameLine();
+        ImGui.TextUnformatted(this.plugin.Connection.IsConnected ? "Connected!" : "Failed to connect!");
+
+
         if (ImGui.IsItemHovered() && !showIndicators) {
             ImGui.SetTooltip(
                 "Because “Show voice activity indicators” is disabled,"


### PR DESCRIPTION
This isn't exactly what's described in #8 but it's a working solution for me. I run DiscordPtb (beta client) alongside the normal Discord client. And of course it usually tries to connect to the wrong one.
This lets me specifically set the port the websocket uses.

---
Added a number input to choose the port, with a big tooltip.
Along with a button to reconnect and a small label showing if its connected or not.

I also added a subcommand `/whostalking port <number>`.

---
If you are interested, but want some changes please let me know. If you are not I would still appreciate a heads-up so I'm aware.
Thank you for the amazing plugin!
